### PR TITLE
Fix doc/code mismatches in API reference and quickstart examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ import (
     "fmt"
     "os"
     
-    "github.com/lexlapax/go-llms/pkg/llm/provider"
+    agentdomain "github.com/lexlapax/go-llms/pkg/agent/domain"
     "github.com/lexlapax/go-llms/pkg/agent/core"
-    "github.com/lexlapax/go-llms/pkg/llm/domain"
+    "github.com/lexlapax/go-llms/pkg/llm/provider"
 )
 
 func main() {
@@ -52,15 +52,17 @@ func main() {
     p := provider.NewOpenAIProvider(os.Getenv("OPENAI_API_KEY"), "gpt-4")
     
     // Create agent
-    agent := core.NewLLMAgent("assistant", "gpt-4", core.LLMDeps{Provider: p})
+    agent := core.NewLLMAgent("assistant", "A helpful AI assistant", core.LLMDeps{Provider: p})
     agent.SetSystemPrompt("You are a helpful assistant.")
     
     // Chat
-    state := domain.NewState()
+    state := agentdomain.NewState()
     state.Set("user_input", "Explain quantum computing in simple terms")
     result, _ := agent.Run(context.Background(), state)
     
-    fmt.Println(result.Get("response"))
+    if response, ok := result.Get("response"); ok {
+        fmt.Println(response)
+    }
 }
 ```
 
@@ -68,7 +70,7 @@ func main() {
 
 ```go
 // Create smart agent with built-in tools
-agent := core.NewLLMAgent("smart-assistant", "gpt-4", core.LLMDeps{Provider: p})
+agent := core.NewLLMAgent("smart-assistant", "A smart assistant with tool access", core.LLMDeps{Provider: p})
 
 // Add powerful tools
 agent.AddTool(web.NewWebSearchTool(webAPIKey))
@@ -108,18 +110,17 @@ data := result.Get("structured_output")
 
 ```go
 // Create specialized agents
-extractor := core.NewLLMAgent("extractor", "gpt-4", core.LLMDeps{Provider: p})
-analyzer := core.NewLLMAgent("analyzer", "claude-3-sonnet-20240229", core.LLMDeps{Provider: claude})
+extractor := core.NewLLMAgent("extractor", "Extracts data from documents", core.LLMDeps{Provider: p})
+analyzer := core.NewLLMAgent("analyzer", "Analyzes extracted data", core.LLMDeps{Provider: claude})
 
 // Orchestrate with workflows
-workflow := workflow.NewSequentialAgent("data-pipeline", []domain.BaseAgent{
-    extractor,  // First: extract data from text
-    analyzer,   // Second: analyze extracted data
-})
+pipeline := workflow.NewSequentialAgent("data-pipeline")
+pipeline.AddSubAgent(extractor)  // First: extract data from text
+pipeline.AddSubAgent(analyzer)   // Second: analyze extracted data
 
 // Process data through the pipeline
 state.Set("document", "Large document content...")
-result, _ := workflow.Run(context.Background(), state)
+result, _ := pipeline.Run(context.Background(), state)
 ```
 
 ## Learning Resources
@@ -234,7 +235,7 @@ go run docs/user-guide/getting-started/quickstart.go
 ## Status
 
 ✅ **Actively Maintained** - Regular updates and improvements  
-✅ **Comprehensive Testing** - 280+ tests with >85% coverage  
+✅ **Comprehensive Testing** - 1,200+ tests with >85% coverage  
 ✅ **Complete Documentation** - User guides, API docs, examples  
 ✅ **Bridge Compatible** - Ready for scripting engine integration  
 

--- a/docs/technical/api-reference/agents.md
+++ b/docs/technical/api-reference/agents.md
@@ -6,197 +6,93 @@ Complete API reference for agent interfaces and implementations in Go-LLMs, cove
 
 ## Core Agent Interfaces
 
-### Agent Interface
+### BaseAgent Interface
 
-The base interface for all agent implementations:
+The core interface that all agent types must implement (`pkg/agent/domain`):
 
 ```go
-package agent
+// BaseAgent defines the core interface for all agent types.
+type BaseAgent interface {
+    // Identification
+    ID() string
+    Name() string
+    Description() string
+    Type() AgentType
 
-// Agent represents an autonomous agent that can execute tasks
-type Agent interface {
-    // Execute runs the agent with the given input
-    Execute(ctx context.Context, input interface{}) (interface{}, error)
-    
-    // GetMetadata returns agent metadata
-    GetMetadata() AgentMetadata
-    
-    // GetConfig returns the current agent configuration
-    GetConfig() AgentConfig
-    
-    // SetConfig updates the agent configuration
-    SetConfig(config AgentConfig) error
-    
-    // Initialize prepares the agent for execution
+    // Hierarchy Management
+    Parent() BaseAgent
+    SetParent(parent BaseAgent) error
+    SubAgents() []BaseAgent
+    AddSubAgent(agent BaseAgent) error
+    RemoveSubAgent(name string) error
+    FindAgent(name string) BaseAgent
+    FindSubAgent(name string) BaseAgent
+
+    // Execution
+    Run(ctx context.Context, input *State) (*State, error)
+    RunAsync(ctx context.Context, input *State) (<-chan Event, error)
+
+    // Lifecycle Hooks
     Initialize(ctx context.Context) error
-    
-    // Shutdown cleans up agent resources
-    Shutdown(ctx context.Context) error
+    BeforeRun(ctx context.Context, state *State) error
+    AfterRun(ctx context.Context, state *State, result *State, err error) error
+    Cleanup(ctx context.Context) error
+
+    // Schema Definition
+    InputSchema() *schema.Schema
+    OutputSchema() *schema.Schema
+
+    // Configuration
+    Config() AgentConfig
+    WithConfig(config AgentConfig) BaseAgent
+    Validate() error
+
+    // Metadata
+    Metadata() map[string]interface{}
+    SetMetadata(key string, value interface{})
 }
 ```
 
-#### Methods
+`AgentType` constants: `"llm"`, `"sequential"`, `"parallel"`, `"conditional"`, `"loop"`, `"custom"`
 
-##### Execute
+#### Key Methods
+
+##### Run
 
 ```go
-Execute(ctx context.Context, input interface{}) (interface{}, error)
+Run(ctx context.Context, input *State) (*State, error)
 ```
 
-Executes the agent's main logic with the provided input.
-
-**Parameters:**
-- `ctx`: Context for cancellation and timeout control
-- `input`: The input data for the agent
-
-**Returns:**
-- `interface{}`: The agent's output
-- `error`: Error if execution fails
+Executes the agent synchronously. Input and output are both `*domain.State` key-value maps.
 
 **Example:**
 ```go
-result, err := agent.Execute(ctx, map[string]interface{}{
-    "task": "analyze data",
-    "data": dataSet,
+import agentdomain "github.com/lexlapax/go-llms/pkg/agent/domain"
+
+state := agentdomain.NewState()
+state.Set("user_input", "Summarize this document")
+result, err := agent.Run(ctx, state)
+if response, ok := result.Get("response"); ok {
+    fmt.Println(response)
 }
 ```
 
-##### GetMetadata
+##### RunAsync
 
 ```go
-GetMetadata() AgentMetadata
+RunAsync(ctx context.Context, input *State) (<-chan Event, error)
 ```
 
-Returns metadata about the agent.
+Executes the agent asynchronously, streaming events as they occur.
 
-**Returns:**
-- `AgentMetadata`: Agent metadata including name, version, and capabilities
-
-### ToolEnabledAgent Interface
-
-Extends Agent with tool execution capabilities:
+##### AddSubAgent / SubAgents
 
 ```go
-// ToolEnabledAgent can use tools to accomplish tasks
-type ToolEnabledAgent interface {
-    Agent
-    
-    // RegisterTool adds a tool to the agent's toolkit
-    RegisterTool(tool Tool) error
-    
-    // UnregisterTool removes a tool from the agent's toolkit
-    UnregisterTool(name string) error
-    
-    // GetTools returns all registered tools
-    GetTools() []Tool
-    
-    // ExecuteTool executes a specific tool by name
-    ExecuteTool(ctx context.Context, name string, input interface{}) (interface{}, error)
-    
-    // GetToolRegistry returns the agent's tool registry
-    GetToolRegistry() ToolRegistry
-}
+AddSubAgent(agent BaseAgent) error
+SubAgents() []BaseAgent
 ```
 
-#### Methods
-
-##### RegisterTool
-
-```go
-RegisterTool(tool Tool) error
-```
-
-Registers a tool for use by the agent.
-
-**Parameters:**
-- `tool`: The tool to register
-
-**Returns:**
-- `error`: Error if registration fails
-
-**Example:**
-```go
-httpTool := tools.GetTool("http_request")
-err := agent.RegisterTool(httpTool)
-```
-
-##### ExecuteTool
-
-```go
-ExecuteTool(ctx context.Context, name string, input interface{}) (interface{}, error)
-```
-
-Executes a specific tool by name.
-
-**Parameters:**
-- `ctx`: Context for cancellation and timeout control
-- `name`: Name of the tool to execute
-- `input`: Input for the tool
-
-**Returns:**
-- `interface{}`: Tool execution result
-- `error`: Error if execution fails
-
-### LLMAgent Interface
-
-Agent powered by a language model:
-
-```go
-// LLMAgent uses a language model for reasoning and decision-making
-type LLMAgent interface {
-    ToolEnabledAgent
-    
-    // SetProvider sets the LLM provider
-    SetProvider(provider Provider) error
-    
-    // GetProvider returns the current LLM provider
-    GetProvider() Provider
-    
-    // SetSystemPrompt sets the system prompt
-    SetSystemPrompt(prompt string)
-    
-    // GetSystemPrompt returns the current system prompt
-    GetSystemPrompt() string
-    
-    // GetConversationHistory returns the conversation history
-    GetConversationHistory() []Message
-    
-    // ClearConversationHistory clears the conversation history
-    ClearConversationHistory()
-    
-    // Complete generates a completion using the LLM
-    Complete(ctx context.Context, messages []Message) (*CompletionResponse, error)
-}
-```
-
-### WorkflowAgent Interface
-
-Agent that orchestrates complex workflows:
-
-```go
-// WorkflowAgent executes multi-step workflows
-type WorkflowAgent interface {
-    Agent
-    
-    // AddStep adds a step to the workflow
-    AddStep(step WorkflowStep) error
-    
-    // RemoveStep removes a step from the workflow
-    RemoveStep(name string) error
-    
-    // GetSteps returns all workflow steps
-    GetSteps() []WorkflowStep
-    
-    // ExecuteWorkflow runs the complete workflow
-    ExecuteWorkflow(ctx context.Context, input interface{}) (*WorkflowResult, error)
-    
-    // ExecuteStep executes a specific step
-    ExecuteStep(ctx context.Context, stepName string, input interface{}) (interface{}, error)
-    
-    // GetWorkflowState returns the current workflow state
-    GetWorkflowState() WorkflowState
-}
-```
+Manage child agents for workflow orchestration (sequential, parallel, etc.).
 
 ## Agent Types and Implementations
 

--- a/docs/technical/api-reference/providers.md
+++ b/docs/technical/api-reference/providers.md
@@ -8,183 +8,119 @@ Complete API reference for LLM provider interfaces and implementations in Go-LLM
 
 ### Provider Interface
 
-The base interface that all LLM providers must implement:
+The base interface that all LLM providers must implement (`pkg/llm/domain`):
 
 ```go
-package llm
-
-// Provider defines the core interface for LLM providers
+// Provider defines the contract that all LLM providers must implement.
 type Provider interface {
-    // Complete generates a completion for the given request
-    Complete(ctx context.Context, request *CompletionRequest) (*CompletionResponse, error)
-    
-    // GetCapabilities returns the capabilities of this provider
-    GetCapabilities() Capabilities
-    
-    // GetModels returns available models for this provider
-    GetModels(ctx context.Context) ([]Model, error)
-    
-    // Close cleans up any resources used by the provider
-    Close() error
+    // Generate produces text from a prompt
+    Generate(ctx context.Context, prompt string, options ...Option) (string, error)
+
+    // GenerateMessage produces text from a list of messages
+    GenerateMessage(ctx context.Context, messages []Message, options ...Option) (Response, error)
+
+    // GenerateWithSchema produces structured output conforming to a schema
+    GenerateWithSchema(ctx context.Context, prompt string, schema *schema.Schema, options ...Option) (interface{}, error)
+
+    // Stream streams responses token by token
+    Stream(ctx context.Context, prompt string, options ...Option) (ResponseStream, error)
+
+    // StreamMessage streams responses from a list of messages
+    StreamMessage(ctx context.Context, messages []Message, options ...Option) (ResponseStream, error)
 }
 ```
 
+`ResponseStream` is a read-only token channel: `type ResponseStream <-chan Token`
+
 #### Methods
 
-##### Complete
+##### Generate
 
 ```go
-Complete(ctx context.Context, request *CompletionRequest) (*CompletionResponse, error)
+Generate(ctx context.Context, prompt string, options ...Option) (string, error)
 ```
 
-Generates a completion based on the provided request.
+Generates text from a prompt string.
 
 **Parameters:**
 - `ctx`: Context for cancellation and timeout control
-- `request`: The completion request containing messages and parameters
+- `prompt`: The input prompt
+- `options`: Optional provider options (temperature, max tokens, etc.)
 
 **Returns:**
-- `*CompletionResponse`: The generated completion
+- `string`: The generated text
 - `error`: Error if the request fails
 
 **Example:**
 ```go
-response, err := provider.Complete(ctx, &CompletionRequest{
-    Messages: []Message{
-        {Role: "user", Content: "What is the capital of France?"},
-    },
-    Model: "gpt-3.5-turbo",
-}
+text, err := provider.Generate(ctx, "What is the capital of France?")
 ```
 
-##### GetCapabilities
+##### GenerateMessage
 
 ```go
-GetCapabilities() Capabilities
+GenerateMessage(ctx context.Context, messages []Message, options ...Option) (Response, error)
 ```
 
-Returns the capabilities supported by this provider.
-
-**Returns:**
-- `Capabilities`: Provider capabilities including supported features
-
-**Example:**
-```go
-caps := provider.GetCapabilities()
-if caps.SupportsStreaming {
-    // Use streaming
-}
-```
-
-##### GetModels
-
-```go
-GetModels(ctx context.Context) ([]Model, error)
-```
-
-Retrieves the list of available models from the provider.
+Generates a response from a list of messages (chat format).
 
 **Parameters:**
 - `ctx`: Context for cancellation and timeout control
+- `messages`: Conversation messages
+- `options`: Optional provider options
 
 **Returns:**
-- `[]Model`: List of available models
+- `Response`: The generated response
 - `error`: Error if the request fails
 
-### StreamingProvider Interface
-
-Extends Provider with streaming capabilities:
+##### GenerateWithSchema
 
 ```go
-// StreamingProvider adds streaming support to the base Provider interface
-type StreamingProvider interface {
-    Provider
-    
-    // CompleteStream generates a streaming completion
-    CompleteStream(ctx context.Context, request *CompletionRequest) (<-chan StreamChunk, error)
-}
+GenerateWithSchema(ctx context.Context, prompt string, schema *schema.Schema, options ...Option) (interface{}, error)
 ```
 
-#### Methods
+Generates structured output that conforms to the provided JSON schema.
 
-##### CompleteStream
+##### Stream
 
 ```go
-CompleteStream(ctx context.Context, request *CompletionRequest) (<-chan StreamChunk, error)
+Stream(ctx context.Context, prompt string, options ...Option) (ResponseStream, error)
 ```
 
-Generates a streaming completion, returning chunks as they become available.
-
-**Parameters:**
-- `ctx`: Context for cancellation and timeout control
-- `request`: The completion request
+Streams response tokens as they are generated.
 
 **Returns:**
-- `<-chan StreamChunk`: Channel of stream chunks
+- `ResponseStream`: A read-only `<-chan Token` channel
 - `error`: Error if the stream setup fails
 
 **Example:**
 ```go
-stream, err := provider.CompleteStream(ctx, request)
+stream, err := provider.Stream(ctx, "Explain Go interfaces")
 if err != nil {
     return err
 }
-
-for chunk := range stream {
-    if chunk.Error != nil {
-        return chunk.Error
-    }
-    fmt.Print(chunk.Delta)
+for token := range stream {
+    fmt.Print(token.Text)
 }
 ```
 
-### EmbeddingProvider Interface
-
-Provides text embedding generation capabilities:
+##### StreamMessage
 
 ```go
-// EmbeddingProvider generates embeddings for text input
-type EmbeddingProvider interface {
-    // CreateEmbedding generates embeddings for the input text
-    CreateEmbedding(ctx context.Context, request *EmbeddingRequest) (*EmbeddingResponse, error)
-    
-    // GetEmbeddingModels returns available embedding models
-    GetEmbeddingModels(ctx context.Context) ([]EmbeddingModel, error)
-}
+StreamMessage(ctx context.Context, messages []Message, options ...Option) (ResponseStream, error)
 ```
 
-#### Methods
+Streams a response from a list of messages.
 
-##### CreateEmbedding
+### ModelRegistry Interface
 
-```go
-CreateEmbedding(ctx context.Context, request *EmbeddingRequest) (*EmbeddingResponse, error)
-```
-
-Generates embeddings for the provided text input.
-
-**Parameters:**
-- `ctx`: Context for cancellation and timeout control
-- `request`: The embedding request
-
-**Returns:**
-- `*EmbeddingResponse`: Generated embeddings
-- `error`: Error if the request fails
-
-### FunctionCallingProvider Interface
-
-Adds function/tool calling capabilities:
+Optional interface for registering and discovering models by name (`pkg/llm/domain`):
 
 ```go
-// FunctionCallingProvider supports function/tool calling
-type FunctionCallingProvider interface {
-    Provider
-    
-    // SupportsFunctionCalling indicates if the provider supports function calling
-    SupportsFunctionCalling() bool
-    
-    // GetFunctionCallModels returns models that support function calling
-    GetFunctionCallModels(ctx context.Context) ([]Model, error)
+type ModelRegistry interface {
+    RegisterModel(name string, provider Provider) error
+    GetModel(name string) (Provider, error)
+    ListModels() []string
 }
 ```
 
@@ -220,11 +156,10 @@ func New(config Config) *Provider
 #### Usage Example
 
 ```go
-import "github.com/lexlapax/go-llms/pkg/llm/provider/openai"
+import "github.com/lexlapax/go-llms/pkg/llm/provider"
 
-provider := provider.NewOpenAIProvider(
-    domain.NewTemperatureOption(&[]float64{0.7}[0]),
-)
+p := provider.NewOpenAIProvider(os.Getenv("OPENAI_API_KEY"), "gpt-4")
+text, err := p.Generate(ctx, "Hello!")
 ```
 
 ### Anthropic Provider
@@ -255,19 +190,10 @@ func New(config Config) *Provider
 #### Usage Example
 
 ```go
-import "github.com/lexlapax/go-llms/pkg/llm/provider/anthropic"
+import "github.com/lexlapax/go-llms/pkg/llm/provider"
 
-provider := provider.NewAnthropicProvider(
-    // APIKey: os.Getenv("ANTHROPIC_API_KEY"), // Moved to constructor parameters
-    Model:  "claude-3-opus-20240229",
-}
-
-response, err := provider.Complete(ctx, &llm.CompletionRequest{
-    Messages: []llm.Message{
-        {Role: "user", Content: "Write a haiku about programming."},
-    },
-    MaxTokens: &[]int{100}[0],
-}
+p := provider.NewAnthropicProvider(os.Getenv("ANTHROPIC_API_KEY"), "claude-3-opus-20240229")
+text, err := p.Generate(ctx, "Write a haiku about programming.")
 ```
 
 ### Google Gemini Provider
@@ -659,7 +585,7 @@ Always use context for proper cancellation:
 ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 defer cancel()
 
-response, err := provider.Complete(ctx, request)
+text, err := provider.Generate(ctx, prompt)
 ```
 
 ### 2. Error Handling
@@ -668,7 +594,7 @@ Handle provider-specific errors appropriately:
 
 ```go
 if err != nil {
-    var providerErr *ProviderError
+    var providerErr *domain.ProviderError
     if errors.As(err, &providerErr) {
         if providerErr.Retryable {
             // Implement retry logic
@@ -677,57 +603,20 @@ if err != nil {
 }
 ```
 
-### 3. Resource Cleanup
-
-Always close providers when done:
-
-```go
-provider := openai.New(config)
-defer provider.Close()
-```
-
-### 4. Model Selection
-
-Check model availability before use:
-
-```go
-models, err := provider.GetModels(ctx)
-if err != nil {
-    return err
-}
-
-// Find suitable model
-var selectedModel *Model
-for _, model := range models {
-    if model.SupportsFunctions && model.ContextLength >= 8000 {
-        selectedModel = &model
-        break
-    }
-}
-```
-
-### 5. Streaming Best Practices
+### 3. Streaming Best Practices
 
 Handle streaming responses properly:
 
 ```go
-stream, err := provider.CompleteStream(ctx, request)
+stream, err := provider.Stream(ctx, prompt)
 if err != nil {
     return err
 }
 
 var fullResponse strings.Builder
-for chunk := range stream {
-    if chunk.Error != nil {
-        return chunk.Error
-    }
-    
-    for _, choice := range chunk.Choices {
-        fullResponse.WriteString(choice.Delta.Content)
-        
-        // Process chunk immediately if needed
-        fmt.Print(choice.Delta.Content)
-    }
+for token := range stream {
+    fullResponse.WriteString(token.Text)
+    fmt.Print(token.Text)
 }
 ```
 

--- a/docs/technical/api-reference/tools.md
+++ b/docs/technical/api-reference/tools.md
@@ -8,205 +8,94 @@ Complete API reference for tool interfaces and implementations in Go-LLMs, cover
 
 ### Tool Interface
 
-The base interface that all tools must implement:
+The base interface that all tools must implement (`pkg/agent/domain`):
 
 ```go
-package tools
-
-// Tool defines the interface for all tools in the system
+// Tool represents an executable capability that can be invoked by LLMs.
 type Tool interface {
-    // Core identification
+    // Core functionality
     Name() string
     Description() string
-    Version() string
-    
-    // Schema definition
-    GetInputSchema() *jsonschema.Schema
-    GetOutputSchema() *jsonschema.Schema
-    
-    // Execution
-    Execute(ctx context.Context, input interface{}) (interface{}, error)
-    
-    // Validation
-    ValidateInput(input interface{}) error
-    ValidateOutput(output interface{}) error
-    
-    // Lifecycle
-    Initialize(ctx context.Context) error
-    Cleanup(ctx context.Context) error
-    
+    Execute(ctx *ToolContext, params interface{}) (interface{}, error)
+
+    // Schema definitions
+    ParameterSchema() *schema.Schema
+    OutputSchema() *schema.Schema
+
+    // LLM guidance
+    UsageInstructions() string
+    Examples() []ToolExample
+    Constraints() []string
+    ErrorGuidance() map[string]string
+
     // Metadata
-    GetMetadata() ToolMetadata
-    GetCapabilities() ToolCapabilities
+    Category() string
+    Tags() []string
+    Version() string
+
+    // Behavioral hints
+    IsDeterministic() bool
+    IsDestructive() bool
+    RequiresConfirmation() bool
+    EstimatedLatency() string // "fast", "medium", or "slow"
+
+    // MCP compatibility
+    ToMCPDefinition() MCPToolDefinition
 }
 ```
 
 #### Methods
 
-##### Name
+##### Name / Description
 
 ```go
 Name() string
+Description() string
 ```
 
-Returns the unique name identifier for the tool.
-
-**Returns:**
-- `string`: Tool name (e.g., "http_request", "file_reader")
-
-**Example:**
-```go
-name := tool.Name() // "http_request"
-```
-
-##### GetInputSchema
-
-```go
-GetInputSchema() *jsonschema.Schema
-```
-
-Returns the JSON Schema defining valid input for the tool.
-
-**Returns:**
-- `*jsonschema.Schema`: Input schema definition
-
-**Example:**
-```go
-schema := tool.GetInputSchema()
-// Use schema to validate input before execution
-```
+Return the tool's unique identifier and human-readable description.
 
 ##### Execute
 
 ```go
-Execute(ctx context.Context, input interface{}) (interface{}, error)
+Execute(ctx *ToolContext, params interface{}) (interface{}, error)
 ```
 
-Executes the tool with the provided input.
+Executes the tool with the provided parameters.
 
 **Parameters:**
-- `ctx`: Context for cancellation and timeout control
-- `input`: The input data (must match input schema)
+- `ctx`: `*ToolContext` carrying execution context and agent state
+- `params`: Input parameters (validated against `ParameterSchema()`)
 
 **Returns:**
 - `interface{}`: Tool execution result
 - `error`: Error if execution fails
 
-**Example:**
+##### ParameterSchema / OutputSchema
+
 ```go
-result, err := tool.Execute(ctx, map[string]interface{}{
-    "url": "https://api.example.com/data",
-    "method": "GET",
-}
+ParameterSchema() *schema.Schema
+OutputSchema() *schema.Schema
 ```
 
-### StatefulTool Interface
+Return JSON schemas for the tool's input parameters and output structure respectively.
 
-Extends Tool with state management capabilities:
+##### LLM Guidance Methods
 
 ```go
-// StatefulTool maintains state across executions
-type StatefulTool interface {
-    Tool
-    
-    // State management
-    GetState() ToolState
-    SetState(state ToolState) error
-    ResetState() error
-    
-    // State persistence
-    SaveState(ctx context.Context) error
-    LoadState(ctx context.Context) error
-    
-    // State versioning
-    GetStateVersion() int64
-    MigrateState(fromVersion int64) error
-}
-
-// ToolState represents tool state
-type ToolState interface {
-    // Basic operations
-    Get(key string) (interface{}, bool)
-    Set(key string, value interface{}) error
-    Delete(key string) error
-    
-    // Bulk operations
-    GetAll() map[string]interface{}
-    Clear() error
-    
-    // Metadata
-    Version() int64
-    Modified() time.Time
-}
+UsageInstructions() string        // When and how to use the tool
+Examples() []ToolExample          // Concrete usage examples
+Constraints() []string            // Known limitations
+ErrorGuidance() map[string]string // Error type → recovery advice
 ```
 
-### AsyncTool Interface
-
-For tools with asynchronous execution:
+##### Behavioral Hints
 
 ```go
-// AsyncTool supports asynchronous execution
-type AsyncTool interface {
-    Tool
-    
-    // Async execution
-    ExecuteAsync(ctx context.Context, input interface{}) (TaskID, error)
-    
-    // Status checking
-    GetStatus(ctx context.Context, taskID TaskID) (TaskStatus, error)
-    GetResult(ctx context.Context, taskID TaskID) (interface{}, error)
-    
-    // Cancellation
-    Cancel(ctx context.Context, taskID TaskID) error
-    
-    // Bulk operations
-    ListTasks(ctx context.Context) ([]TaskInfo, error)
-    CancelAll(ctx context.Context) error
-}
-
-// TaskStatus represents async task status
-type TaskStatus string
-
-const (
-    TaskStatusPending   TaskStatus = "pending"
-    TaskStatusRunning   TaskStatus = "running"
-    TaskStatusCompleted TaskStatus = "completed"
-    TaskStatusFailed    TaskStatus = "failed"
-    TaskStatusCancelled TaskStatus = "cancelled"
-)
-```
-
-### StreamingTool Interface
-
-For tools that produce streaming output:
-
-```go
-// StreamingTool supports streaming output
-type StreamingTool interface {
-    Tool
-    
-    // Streaming execution
-    ExecuteStream(ctx context.Context, input interface{}) (<-chan StreamChunk, error)
-    
-    // Stream control
-    SupportsBackpressure() bool
-    SetBufferSize(size int) error
-}
-
-// StreamChunk represents a chunk of streaming data
-type StreamChunk struct {
-    Data      interface{} `json:"data"`
-    Metadata  StreamMeta  `json:"metadata"`
-    Error     error       `json:"error,omitempty"`
-    Final     bool        `json:"final"`
-}
-
-// StreamMeta contains streaming metadata
-type StreamMeta struct {
-    Sequence  int64     `json:"sequence"`
-    Timestamp time.Time `json:"timestamp"`
-    Type      string    `json:"type"`
-}
+IsDeterministic() bool      // Same input always produces same output
+IsDestructive() bool        // Tool modifies state or has side effects
+RequiresConfirmation() bool // Needs user confirmation before execution
+EstimatedLatency() string   // "fast", "medium", or "slow"
 ```
 
 ## Tool Registry

--- a/docs/user-guide/getting-started/quickstart.md
+++ b/docs/user-guide/getting-started/quickstart.md
@@ -50,9 +50,9 @@ import (
     "log"
     "os"
 
-    "github.com/lexlapax/go-llms/pkg/llm/provider"
+    agentdomain "github.com/lexlapax/go-llms/pkg/agent/domain"
     "github.com/lexlapax/go-llms/pkg/agent/core"
-    "github.com/lexlapax/go-llms/pkg/llm/domain"
+    "github.com/lexlapax/go-llms/pkg/llm/provider"
 )
 
 func main() {
@@ -66,15 +66,15 @@ func main() {
     openaiProvider := provider.NewOpenAIProvider(apiKey, "gpt-4")
     
     // Create an agent
-    agent := core.NewLLMAgent("assistant", "gpt-4", core.LLMDeps{
+    agent := core.NewLLMAgent("assistant", "A helpful AI assistant", core.LLMDeps{
         Provider: openaiProvider,
-}
+    })
     
     // Set system prompt
     agent.SetSystemPrompt("You are a helpful assistant.")
     
     // Create state with user input
-    state := domain.NewState()
+    state := agentdomain.NewState()
     state.Set("user_input", "Hello! What can you help me with today?")
     
     // Run the agent
@@ -151,9 +151,9 @@ if anthropicKey == "" {
 anthropicProvider := provider.NewAnthropicProvider(anthropicKey, "claude-3-sonnet-20240229")
 
 // Use in agent
-agent := core.NewLLMAgent("assistant", "claude-3-sonnet-20240229", core.LLMDeps{
+agent := core.NewLLMAgent("assistant", "A helpful AI assistant", core.LLMDeps{
     Provider: anthropicProvider,
-}
+})
 ```
 
 ### Common Issues and Solutions


### PR DESCRIPTION
- quickstart.md: fix missing }) syntax error on NewLLMAgent call; fix import
  pkg/llm/domain -> pkg/agent/domain (NewState lives there, not llm/domain)
- quickstart.md + README: fix description arg — second param is agent description,
  not a model name; pass meaningful strings instead of "gpt-4"
- README: fix NewSequentialAgent call — actual signature takes only a name; agents
  are added via AddSubAgent(), not a []BaseAgent slice constructor arg
- README: fix result.Get("response") call — returns (interface{}, bool), not a
  single value; unpack the tuple before passing to fmt.Println
- README: update test count from "280+" to "1,200+" (actual: 1,238 functions)
- providers.md: replace fabricated Provider interface (Complete/GetCapabilities/
  GetModels/Close) with real one (Generate/GenerateMessage/GenerateWithSchema/
  Stream/StreamMessage); remove non-existent StreamingProvider/EmbeddingProvider/
  FunctionCallingProvider; add real ModelRegistry; fix all code examples
- tools.md: replace fabricated Tool interface (GetInputSchema/ValidateInput/
  Initialize/Cleanup/GetMetadata) with real one (ParameterSchema/OutputSchema/
  UsageInstructions/Examples/Constraints/ErrorGuidance/behavioral hints/
  ToMCPDefinition); remove non-existent StatefulTool/AsyncTool/StreamingTool
- agents.md: replace fabricated Agent interface (Execute(ctx, input interface{}))
  with real BaseAgent interface (Run/RunAsync/hierarchy/lifecycle hooks)
